### PR TITLE
[Fix] Remove cascade delete from Blocklist entity relationships

### DIFF
--- a/src/main/java/org/dfbf/soundlink/domain/blocklist/entity/Blocklist.java
+++ b/src/main/java/org/dfbf/soundlink/domain/blocklist/entity/Blocklist.java
@@ -20,11 +20,11 @@ public class Blocklist {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long blocklistId;
 
-    @ManyToOne (cascade = CascadeType.REMOVE)
+    @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne (cascade = CascadeType.REMOVE)
+    @ManyToOne
     @JoinColumn(name = "blocked_user_id")
     private User blockedUser;
 


### PR DESCRIPTION
The `cascade = CascadeType.REMOVE` property was removed from the `@ManyToOne` relationships in the `Blocklist` entity. This ensures that deleting a `Blocklist` entry does not unintentionally delete associated `User` entities.