### PR TITLE
Feat/emotion record/main

### DIFF
--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/dto/request/EmotionRecordRequestDTO.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/dto/request/EmotionRecordRequestDTO.java
@@ -5,12 +5,10 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import org.dfbf.soundlink.global.comm.enums.Emotions;
 
-import java.sql.Timestamp;
-
 public record EmotionRecordRequestDTO(
 
         @NotNull(message = "spotifyId 필요")
-        Long spotifyId,
+        String spotifyId,
 
         @NotBlank(message = "title 필요")
         String title,
@@ -25,8 +23,6 @@ public record EmotionRecordRequestDTO(
 
         @NotBlank(message = "comment 필요")
         @Size(max = 200, message = "comment는 200자 이내여야 합니다.")
-        String comment,
-
-        Timestamp createAt
+        String comment
 ) {
 }

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/dto/request/EmotionRecordUpdateRequestDTO.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/dto/request/EmotionRecordUpdateRequestDTO.java
@@ -1,7 +1,7 @@
 package org.dfbf.soundlink.domain.emotionRecord.dto.request;
 
 public record EmotionRecordUpdateRequestDTO(
-        Long spotifyId,
+        String spotifyId,
         String title,
         String artist,
         String albumImage,

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/dto/response/EmotionRecordResponseWithOwnerDTO.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/dto/response/EmotionRecordResponseWithOwnerDTO.java
@@ -8,6 +8,7 @@ import java.time.format.DateTimeFormatter;
 public record EmotionRecordResponseWithOwnerDTO(
         Long recordId,
         String nickName,
+        String loginId,
         String emotion,
         SpotifyMusicResponseDTO spotifyMusic,
         String comment,
@@ -18,6 +19,7 @@ public record EmotionRecordResponseWithOwnerDTO(
         return new EmotionRecordResponseWithOwnerDTO(
                 record.getRecordId(),
                 record.getUser().getNickname(),
+                record.getUser().getLoginId(),
                 record.getEmotion().name(),
                 record.getSpotifyMusic() != null ? SpotifyMusicResponseDTO.fromEntity(record.getSpotifyMusic()) : null,
                 record.getComment(),

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/dto/response/EmotionRecordUpdateResponseDTO.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/dto/response/EmotionRecordUpdateResponseDTO.java
@@ -4,7 +4,7 @@ import org.dfbf.soundlink.domain.emotionRecord.entity.EmotionRecord;
 
 public record EmotionRecordUpdateResponseDTO(
         Long recordId,
-        String spotifyId,
+        Long spotifyId,
         String title,
         String artist,
         String albumImage,
@@ -14,7 +14,7 @@ public record EmotionRecordUpdateResponseDTO(
     public static EmotionRecordUpdateResponseDTO fromEntity(EmotionRecord record) {
         return new EmotionRecordUpdateResponseDTO(
                 record.getRecordId(),
-                String.valueOf(record.getSpotifyMusic().getSpotifyId()),
+                record.getSpotifyMusic().getSpotifyId(),
                 record.getSpotifyMusic().getTitle(),
                 record.getSpotifyMusic().getArtist(),
                 record.getSpotifyMusic().getAlbumImage(),

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/dto/response/SpotifyMusicResponseDTO.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/dto/response/SpotifyMusicResponseDTO.java
@@ -2,10 +2,10 @@ package org.dfbf.soundlink.domain.emotionRecord.dto.response;
 
 import org.dfbf.soundlink.domain.emotionRecord.entity.SpotifyMusic;
 
-public record SpotifyMusicResponseDTO(String spotifyId, String title, String artist, String albumImage) {
+public record SpotifyMusicResponseDTO(Long spotifyId, String title, String artist, String albumImage) {
     public static SpotifyMusicResponseDTO fromEntity(SpotifyMusic music) {
         return new SpotifyMusicResponseDTO(
-                String.valueOf(music.getSpotifyId()),
+                music.getSpotifyId(),
                 music.getTitle(),
                 music.getArtist(),
                 music.getAlbumImage()

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/entity/EmotionRecord.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/entity/EmotionRecord.java
@@ -28,7 +28,7 @@ public class EmotionRecord {
     private Emotions emotion;
 
     @ManyToOne
-    @JoinColumn(name = "spotify_music_id")
+    @JoinColumn(name = "spotify_id")
     private SpotifyMusic spotifyMusic;
 
     @Column(name = "comment")

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
@@ -41,22 +41,23 @@ public class EmotionRecordService {
                 .orElseThrow(UserNotFoundException::new);
 
         try {
-            // 감정 기록 저장
-            EmotionRecord emotionRecord = EmotionRecord.builder()
-                    .user(loggedInUser)
-                    .emotion(request.emotion())
-                    .comment(request.comment())
-                    .build();
-            emotionRecordRepository.save(emotionRecord);
-
             // 음악 저장
             SpotifyMusic spotifyMusic = SpotifyMusic.builder()
-                    .spotifyId(request.spotifyId())
+                    .spotifyId(Long.valueOf(request.spotifyId()))
                     .title(request.title())
                     .artist(request.artist())
                     .albumImage(request.albumImage())
                     .build();
             spotifyMusicRepository.save(spotifyMusic);
+
+            // 감정 기록 저장
+            EmotionRecord emotionRecord = EmotionRecord.builder()
+                    .user(loggedInUser)
+                    .emotion(request.emotion())
+                    .comment(request.comment())
+                    .spotifyMusic(spotifyMusic)
+                    .build();
+            emotionRecordRepository.save(emotionRecord);
 
             return new ResponseResult(ErrorCode.SUCCESS);
         } catch (UserNotFoundException e) {
@@ -133,10 +134,10 @@ public class EmotionRecordService {
             // SpotifyMusic이 DB에 있는지 먼저 확인
             // SpotifyMusic 엔티티가 저장되지 않은 상태에서 EmotionRecord 저장 시 영속성 컨텍스트 미저장 오류 발생
             // EmotionRecord를 업데이트하기 전에 SpotifyMusic이 없다면 생성 후 먼저 저장해줘야 함
-            SpotifyMusic spotifyMusic = spotifyMusicRepository.findById(updateDTO.spotifyId())
+            SpotifyMusic spotifyMusic = spotifyMusicRepository.findById(Long.valueOf(updateDTO.spotifyId()))
                     .orElseGet(() -> {
                         SpotifyMusic newMusic = new SpotifyMusic(
-                                updateDTO.spotifyId(),
+                                Long.valueOf(updateDTO.spotifyId()),
                                 updateDTO.title(),
                                 updateDTO.artist(),
                                 updateDTO.albumImage()


### PR DESCRIPTION
엔티티 저장 순서 변경 및 수정
Entity 컬럼명 수정, request spotifyId 값 String 타입으로 반환 및 response spotifyId 값 Long 타입으로 반환하도록 수정
상세 페이지 response에 longinId(태그 값) 추가