### PR TITLE
[Fix]: 401 에러 처리 개선 및 유효한 AT,RT에 의한 토큰 재발급 기능 구현 #29

### DIFF
--- a/src/main/java/org/dfbf/soundlink/domain/user/service/UserService.java
+++ b/src/main/java/org/dfbf/soundlink/domain/user/service/UserService.java
@@ -47,9 +47,7 @@ public class UserService {
     private final RedisService redisService;
 
     private final JwtProvider jwtProvider;
-    private final TokenProperties tokenProperties;
 
-    private RedisTemplate<String, String> redisTemplate;
     private final TokenService tokenService;
   
     private final String domain = "";
@@ -222,7 +220,6 @@ public class UserService {
 
             return new ResponseResult(responseBody);
         } catch (Exception e) {
-            System.out.println("[ERROR] " + e.getMessage());
             return new ResponseResult(ErrorCode. INTERNAL_SERVER_ERROR);
         }
     }
@@ -283,7 +280,7 @@ public class UserService {
         }
     }
 
-    // 토큰 재발급
+    // 토큰 재발급(AT O, RT O => AT,RT 재발급)
     public ResponseResult reissueToken(HttpServletRequest request, HttpServletResponse response) {
         String accessToken = jwtProvider.resolveAccessToken(request);
         String refreshToken = jwtProvider.resolveRefreshToken(request);
@@ -307,10 +304,10 @@ public class UserService {
             return new ResponseResult(ErrorCode.TOKEN_INVALID, "RT가 존재하지 않거나 만료되었습니다.");
         }
 
-        // AccessToken 유효성 확인
-        if (jwtProvider.validateToken(accessToken)) {
-            return new ResponseResult(ErrorCode.TOKEN_NOT_EXPIRED); // 유효한 액세스 토큰: 재발급 x
-        }
+//        // AccessToken 유효성 확인
+//        if (jwtProvider.validateToken(accessToken)) {
+//            return new ResponseResult(ErrorCode.TOKEN_NOT_EXPIRED); // 유효한 액세스 토큰: 재발급 x
+//        }
 
         // RefreshToken 유효성 확인
         if (jwtProvider.validateToken(refreshToken)) {
@@ -324,8 +321,8 @@ public class UserService {
                 String newAccessToken = jwtProvider.createAccessToken(userId);
                 String newRefreshToken = jwtProvider.createRefreshToken(userId);
 
-                System.out.println("New AccessToken: " + newAccessToken);
-                System.out.println("New RefreshToken: " + newRefreshToken);
+//                System.out.println("New AccessToken: " + newAccessToken);
+//                System.out.println("New RefreshToken: " + newRefreshToken);
 
                 //레디스에 새로운 리프레시 토큰 업데이트!
                 tokenService.updateRefreshToken(userId, newRefreshToken);

--- a/src/main/java/org/dfbf/soundlink/domain/user/service/UserService.java
+++ b/src/main/java/org/dfbf/soundlink/domain/user/service/UserService.java
@@ -285,9 +285,6 @@ public class UserService {
         String accessToken = jwtProvider.resolveAccessToken(request);
         String refreshToken = jwtProvider.resolveRefreshToken(request);
 
-//        System.out.println("AccessToken: " + accessToken);
-//        System.out.println("RefreshToken from Cookie: " + refreshToken);
-
         // AccessToken과 RefreshToken이 모두 없는 경우
         if (accessToken == null && refreshToken == null) {
             logout(response,request);
@@ -304,11 +301,6 @@ public class UserService {
             return new ResponseResult(ErrorCode.TOKEN_INVALID, "RT가 존재하지 않거나 만료되었습니다.");
         }
 
-//        // AccessToken 유효성 확인
-//        if (jwtProvider.validateToken(accessToken)) {
-//            return new ResponseResult(ErrorCode.TOKEN_NOT_EXPIRED); // 유효한 액세스 토큰: 재발급 x
-//        }
-
         // RefreshToken 유효성 확인
         if (jwtProvider.validateToken(refreshToken)) {
             Long userId = jwtProvider.getUserId(refreshToken);
@@ -320,9 +312,6 @@ public class UserService {
             if (redisRefreshToken != null && redisRefreshToken.equals(refreshToken)) {
                 String newAccessToken = jwtProvider.createAccessToken(userId);
                 String newRefreshToken = jwtProvider.createRefreshToken(userId);
-
-//                System.out.println("New AccessToken: " + newAccessToken);
-//                System.out.println("New RefreshToken: " + newRefreshToken);
 
                 //레디스에 새로운 리프레시 토큰 업데이트!
                 tokenService.updateRefreshToken(userId, newRefreshToken);

--- a/src/main/java/org/dfbf/soundlink/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/org/dfbf/soundlink/global/auth/JwtAuthenticationFilter.java
@@ -44,11 +44,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response); // 필터 체인 진행(전달)
 
         } catch (ExpiredJwtException ex) {
-            System.out.println("[ERROR] Expired Token: " + accessToken); // 만료된 토큰 로그 출력
             handleException(response, ErrorCode.TOKEN_EXPIRED);
 
         } catch (JwtException ex) {
-            System.out.println("[ERROR] Invalid Token: " + accessToken); // 유효하지 않은 토큰 로그 출력
             handleException(response, ErrorCode.TOKEN_INVALID);
 
         } catch (Exception ex) {

--- a/src/main/java/org/dfbf/soundlink/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/org/dfbf/soundlink/global/auth/JwtAuthenticationFilter.java
@@ -10,11 +10,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.dfbf.soundlink.global.exception.ErrorCode;
 import org.dfbf.soundlink.global.exception.ResponseResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -22,16 +19,44 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        String accessToken = jwtProvider.resolveAccessToken(request);       //1.Access Token 추출
+        String accessToken = null;
+        try {
+            accessToken = jwtProvider.resolveAccessToken(request); // 1. Access Token 추출
 
-        if(accessToken !=null && jwtProvider.validateToken(accessToken)) {  //2.유효성 검사
-            this.setAuthentication(accessToken);                            //3.유저정보 저장
+            if (accessToken != null) {
+                // 2. 유효성 검사
+                if (!jwtProvider.validateToken(accessToken)) {
+                    throw new JwtException("Invalid token");
+                }
+
+                // 3. 만료 여부 검사
+                if (jwtProvider.isTokenExpired(accessToken)) {
+                    throw new ExpiredJwtException(null, null, "Token expired");
+                }
+
+                // 4. 유저정보 저장
+                this.setAuthentication(accessToken);
+            }
+            filterChain.doFilter(request, response); // 필터 체인 진행(전달)
+
+        } catch (ExpiredJwtException ex) {
+            System.out.println("[ERROR] Expired Token: " + accessToken); // 만료된 토큰 로그 출력
+            handleException(response, ErrorCode.TOKEN_EXPIRED);
+
+        } catch (JwtException ex) {
+            System.out.println("[ERROR] Invalid Token: " + accessToken); // 유효하지 않은 토큰 로그 출력
+            handleException(response, ErrorCode.TOKEN_INVALID);
+
+        } catch (Exception ex) {
+            handleException(response, ErrorCode.INTERNAL_SERVER_ERROR);
         }
-        filterChain.doFilter(request, response); //필터 체인 진행(전달)
     }
+
+
 
     //유저정보 저장
     public void setAuthentication(String token) {
@@ -49,6 +74,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // 인증정보 설정
         SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+    // 예외 발생 시 JSON 응답을 반환하는 메서드
+    private void handleException(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        ResponseResult responseResult = new ResponseResult(errorCode);
+
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(responseResult));
     }
 
 }

--- a/src/main/java/org/dfbf/soundlink/global/auth/JwtProvider.java
+++ b/src/main/java/org/dfbf/soundlink/global/auth/JwtProvider.java
@@ -1,13 +1,8 @@
 package org.dfbf.soundlink.global.auth;
 
-import ch.qos.logback.core.subst.Token;
 import io.jsonwebtoken.security.Keys;
-import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
-import org.dfbf.soundlink.domain.user.exception.ExpiredTokenException;
-import org.dfbf.soundlink.global.exception.ErrorCode;
-import org.dfbf.soundlink.global.exception.ResponseResult;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -28,7 +23,7 @@ public class JwtProvider {
     @Value("${REFRESH_TOKEN_EXPIRATION_TIME}")
     private long REFRESH_EXPIRATION_TIME;
 
-    //시크릿 키 자동 생성
+    //시크릿 키
     private final SecretKey SECRET_KEY = Keys.secretKeyFor(SignatureAlgorithm.HS256);
 
     @Autowired
@@ -80,6 +75,19 @@ public class JwtProvider {
         }
     }
 
+    public boolean isTokenExpired(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(SECRET_KEY)
+                    .build()
+                    .parseClaimsJws(token); // 만료된 토큰을 처리하려면 ExpiredJwtException이 발생함
+            return false; // 만료되지 않으면 false
+        } catch (ExpiredJwtException ex) {
+            return true; // 만료된 경우 true
+        } catch (Exception ex) {
+            return false; // 다른 예외는 false
+        }
+    }
 
 
     //액세스토큰 추출

--- a/src/main/java/org/dfbf/soundlink/global/exception/ErrorCode.java
+++ b/src/main/java/org/dfbf/soundlink/global/exception/ErrorCode.java
@@ -46,9 +46,9 @@ public enum ErrorCode {
 
     // Auth
     TOKEN_NOT_EXPIRED(HttpStatus.OK, "토큰 정상"),
-    TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "토큰 만료됨"),
-    TOKEN_TAMPERED(HttpStatus.BAD_REQUEST, "토큰 변조됨"),
-    TOKEN_INVALID(HttpStatus.BAD_REQUEST,"유효하지 않은 토큰"),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰 만료됨"),
+    TOKEN_TAMPERED(HttpStatus.UNAUTHORIZED, "토큰 변조됨"),
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED,"유효하지 않은 토큰"),
 
     // 카카오페이 결제 에러
     KAKAOPAY_READY_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "카카오페이 결제 준비 에러"),


### PR DESCRIPTION
- 토큰 만료시 401에러 처리

![스크린샷 2025-02-26 오후 5 28 20](https://github.com/user-attachments/assets/6af900e2-d831-4932-9540-a7c0aa011b1a)
유효한 AT,RT에 의한 토큰 재발급 기능 구현