### PR TITLE
feat/spotifyMusic/main

### DIFF
--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/controller/EmotionRecordController.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/controller/EmotionRecordController.java
@@ -72,6 +72,16 @@ public class EmotionRecordController {
         return emotionRecordService.getEmotionRecord(userId, recordId);
     }
 
+    @GetMapping("/spotify-video")
+    @Operation(
+            summary = "SpotifyID에 해당하는 VideoID 조회 API",
+            description = "SpotifyID에 해당하는 VideoID를 조회합니다."
+    )
+    public ResponseResult getVideoIdBySpotifyId(
+            @RequestParam String spotifyId) {
+        return emotionRecordService.getVideoIdBySpotifyId(spotifyId);
+    }
+
     @PutMapping("/{recordId}")
     @Operation(
             summary = "감정 기록 수정 API",

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/dto/request/EmotionRecordRequestDTO.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/dto/request/EmotionRecordRequestDTO.java
@@ -10,6 +10,8 @@ public record EmotionRecordRequestDTO(
         @NotNull(message = "spotifyId 필요")
         String spotifyId,
 
+        String videoId,
+
         @NotBlank(message = "title 필요")
         String title,
 

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/dto/request/EmotionRecordUpdateRequestDTO.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/dto/request/EmotionRecordUpdateRequestDTO.java
@@ -2,6 +2,7 @@ package org.dfbf.soundlink.domain.emotionRecord.dto.request;
 
 public record EmotionRecordUpdateRequestDTO(
         String spotifyId,
+        String videoId,
         String title,
         String artist,
         String albumImage,

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/dto/response/EmotionRecordUpdateResponseDTO.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/dto/response/EmotionRecordUpdateResponseDTO.java
@@ -4,6 +4,7 @@ import org.dfbf.soundlink.domain.emotionRecord.entity.EmotionRecord;
 
 public record EmotionRecordUpdateResponseDTO(
         Long recordId,
+        String videoId,
         String spotifyId,
         String title,
         String artist,
@@ -15,6 +16,7 @@ public record EmotionRecordUpdateResponseDTO(
         return new EmotionRecordUpdateResponseDTO(
                 record.getRecordId(),
                 record.getSpotifyMusic().getSpotifyId(),
+                record.getSpotifyMusic().getVideoId(),
                 record.getSpotifyMusic().getTitle(),
                 record.getSpotifyMusic().getArtist(),
                 record.getSpotifyMusic().getAlbumImage(),

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/dto/response/SpotifyMusicResponseDTO.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/dto/response/SpotifyMusicResponseDTO.java
@@ -2,10 +2,11 @@ package org.dfbf.soundlink.domain.emotionRecord.dto.response;
 
 import org.dfbf.soundlink.domain.emotionRecord.entity.SpotifyMusic;
 
-public record SpotifyMusicResponseDTO(String spotifyId, String title, String artist, String albumImage) {
+public record SpotifyMusicResponseDTO(String spotifyId, String videoId, String title, String artist, String albumImage) {
     public static SpotifyMusicResponseDTO fromEntity(SpotifyMusic music) {
         return new SpotifyMusicResponseDTO(
                 music.getSpotifyId(),
+                music.getVideoId(),
                 music.getTitle(),
                 music.getArtist(),
                 music.getAlbumImage()

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/entity/SpotifyMusic.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/entity/SpotifyMusic.java
@@ -44,8 +44,9 @@ public class SpotifyMusic {
     private Timestamp updatedAt;
 
     @Builder
-    public SpotifyMusic (String spotifyId, String title, String artist, String albumImage) {
+    public SpotifyMusic (String spotifyId, String videoId, String title, String artist, String albumImage) {
         this.spotifyId = spotifyId;
+        this.videoId = videoId;
         this.title = title;
         this.artist = artist;
         this.albumImage = albumImage;

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/exception/SpotifyMusicNotFoundException.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/exception/SpotifyMusicNotFoundException.java
@@ -1,0 +1,10 @@
+package org.dfbf.soundlink.domain.emotionRecord.exception;
+
+import org.dfbf.soundlink.global.exception.BusinessException;
+import org.dfbf.soundlink.global.exception.ErrorCode;
+
+public class SpotifyMusicNotFoundException extends BusinessException {
+    public SpotifyMusicNotFoundException() {
+        super(ErrorCode.FAIL_TO_FIND_SPOTIFY_MUSIC);
+    }
+}

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
@@ -8,6 +8,7 @@ import org.dfbf.soundlink.domain.emotionRecord.dto.response.*;
 import org.dfbf.soundlink.domain.emotionRecord.entity.EmotionRecord;
 import org.dfbf.soundlink.domain.emotionRecord.entity.SpotifyMusic;
 import org.dfbf.soundlink.domain.emotionRecord.exception.EmotionRecordNotFoundException;
+import org.dfbf.soundlink.domain.emotionRecord.exception.SpotifyMusicNotFoundException;
 import org.dfbf.soundlink.domain.emotionRecord.exception.UserNotFoundException;
 import org.dfbf.soundlink.domain.emotionRecord.repository.EmotionRecordRepository;
 import org.dfbf.soundlink.domain.emotionRecord.repository.SpotifyMusicRepository;
@@ -151,11 +152,13 @@ public class EmotionRecordService {
     public ResponseResult getVideoIdBySpotifyId(String spotifyId) {
 
         try {
-            String videoId = spotifyMusicRepository.findBySpotifyId(spotifyId)
-                    .map(SpotifyMusic::getVideoId)
-                    .orElse(null);
+            SpotifyMusic music = spotifyMusicRepository.findBySpotifyId(spotifyId)
+                    .orElseThrow(SpotifyMusicNotFoundException::new);
 
+            String videoId = music.getVideoId();
             return new ResponseResult(ErrorCode.SUCCESS, videoId);
+        } catch (SpotifyMusicNotFoundException e) {
+            return new ResponseResult(ErrorCode.FAIL_TO_FIND_SPOTIFY_MUSIC, e.getMessage());
         } catch (DataAccessException e) {
             return new ResponseResult(ErrorCode.DB_ERROR, e.getMessage());
         } catch (Exception e) {

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
@@ -180,6 +180,7 @@ public class EmotionRecordService {
                     .orElseGet(() -> {
                         SpotifyMusic newMusic = new SpotifyMusic(
                                 updateDTO.spotifyId(),
+                                updateDTO.videoId(),
                                 updateDTO.title(),
                                 updateDTO.artist(),
                                 updateDTO.albumImage()

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
@@ -147,6 +147,22 @@ public class EmotionRecordService {
         }
     }
 
+    @Transactional(readOnly = true)
+    public ResponseResult getVideoIdBySpotifyId(String spotifyId) {
+
+        try {
+            String videoId = spotifyMusicRepository.findBySpotifyId(spotifyId)
+                    .map(SpotifyMusic::getVideoId)
+                    .orElse(null);
+
+            return new ResponseResult(ErrorCode.SUCCESS, videoId);
+        } catch (DataAccessException e) {
+            return new ResponseResult(ErrorCode.DB_ERROR, e.getMessage());
+        } catch (Exception e) {
+            return new ResponseResult(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
+        }
+    }
+
     @Transactional
     public ResponseResult updateEmotionRecord(Long recordId, EmotionRecordUpdateRequestDTO updateDTO) {
         try {

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
@@ -179,13 +179,13 @@ public class EmotionRecordService {
             // EmotionRecord를 업데이트하기 전에 SpotifyMusic이 없다면 생성 후 먼저 저장해줘야 함
             SpotifyMusic spotifyMusic = spotifyMusicRepository.findBySpotifyId(updateDTO.spotifyId())
                     .orElseGet(() -> {
-                        SpotifyMusic newMusic = new SpotifyMusic(
-                                updateDTO.spotifyId(),
-                                updateDTO.videoId(),
-                                updateDTO.title(),
-                                updateDTO.artist(),
-                                updateDTO.albumImage()
-                        );
+                        SpotifyMusic newMusic = SpotifyMusic.builder()
+                                .spotifyId(updateDTO.spotifyId())
+                                .title(updateDTO.title())
+                                .artist(updateDTO.artist())
+                                .albumImage(updateDTO.albumImage())
+                                .build();
+
                         return spotifyMusicRepository.save(newMusic);
                     });
 

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
@@ -46,6 +46,7 @@ public class EmotionRecordService {
             // 음악 저장
             SpotifyMusic spotifyMusic = SpotifyMusic.builder()
                     .spotifyId(request.spotifyId())
+                    .videoId(request.videoId())
                     .title(request.title())
                     .artist(request.artist())
                     .albumImage(request.albumImage())

--- a/src/main/java/org/dfbf/soundlink/global/exception/ErrorCode.java
+++ b/src/main/java/org/dfbf/soundlink/global/exception/ErrorCode.java
@@ -52,6 +52,9 @@ public enum ErrorCode {
     FAIL_TO_FIND_EMOTION(HttpStatus.NOT_FOUND, "해당 감정을 찾을 수 없습니다."),
     INVALID_PAGE_REQUEST(HttpStatus.BAD_REQUEST, "페이지 요청 값이 잘못되었습니다."),
 
+    // SpotifyMusic
+    FAIL_TO_FIND_SPOTIFY_MUSIC(HttpStatus.NOT_FOUND, "해당 SpotifyId를 찾을 수 없습니다."),
+
     // Auth
     TOKEN_NOT_EXPIRED(HttpStatus.OK, "토큰 정상"),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰 만료됨"),


### PR DESCRIPTION
SpotifyID에 해당하는 VideoID를 조회 및 컬럼 추가로 인한 EmotionRecord DTO 수정