### PR TITLE
feat/emotionRecord/search

### DIFF
--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordCacheService.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordCacheService.java
@@ -16,7 +16,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -143,12 +142,12 @@ public class EmotionRecordCacheService {
                             throw new IllegalArgumentException("잘못된 감정 값이 포함되어 있습니다: " + e);
                         }
                     })
-                    .collect(Collectors.toList());
+                    .toList();
         }
         Page<EmotionRecord> recordsPage = emotionRecordRepository.findByFilters(userId, emotionEnums, spotifyId, pageable);
         List<EmotionRecordResponseMainDTO> dtoList = recordsPage.getContent().stream()
                 .map(EmotionRecordResponseMainDTO::fromEntity)
-                .collect(Collectors.toList());
+                .toList();
         return EmotionRecordPageResponseDTO.fromPage(recordsPage, dtoList);
     }
 

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordCacheService.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordCacheService.java
@@ -1,0 +1,166 @@
+package org.dfbf.soundlink.domain.emotionRecord.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.dfbf.soundlink.domain.emotionRecord.dto.response.EmotionRecordPageResponseDTO;
+import org.dfbf.soundlink.domain.emotionRecord.dto.response.EmotionRecordResponseMainDTO;
+import org.dfbf.soundlink.domain.emotionRecord.entity.EmotionRecord;
+import org.dfbf.soundlink.domain.emotionRecord.repository.EmotionRecordRepository;
+import org.dfbf.soundlink.global.comm.enums.Emotions;
+import org.dfbf.soundlink.global.util.CacheKeyGenerator;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmotionRecordCacheService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final EmotionRecordRepository emotionRecordRepository;
+
+    /**
+     * 캐시 조회 및 Fallback 처리
+     * 조회 시, 캐시 키를 통해 데이터를 가져오고, 캐시 접근 오류 시,
+     * DB에서 데이터를 조회한 결과를 캐시에 저장 후 반환
+     */
+    public EmotionRecordPageResponseDTO<EmotionRecordResponseMainDTO> getEmotionRecords(
+            Long userId,
+            List<String> emotionList,
+            String spotifyId,
+            int page,
+            int size) {
+
+        // emotion 별 개별 키 생성
+        List<String> keys = CacheKeyGenerator.generateKeysForEmotions(userId, spotifyId, emotionList, page, size);
+
+        // multiGet을 사용하여 각 키에 해당하는 캐시 데이터를 가져옴
+        List<Object> cachedResults = null;
+
+        try {
+            cachedResults = redisTemplate.opsForValue().multiGet(keys);
+        } catch (Exception e) {
+            log.error("캐시 접근 오류 - keys {}: {}", keys, e.getMessage());
+        }
+
+        // 캐시에서 결과가 모두 존재 시, (모든 감정에 대해 캐시 값이 있다면)
+        // 여러 감정 조건에 따른 결과(각각 캐싱해 둔 것)를 합쳐서 반환
+        if (cachedResults != null && cachedResults.stream().allMatch(Objects::nonNull)) {
+            log.info("캐시 hit: {}", keys);
+
+            List<EmotionRecordResponseMainDTO> emotionRecords = new ArrayList<>();
+            for (Object cachedResult : cachedResults) {
+                @SuppressWarnings("unchecked")
+                EmotionRecordPageResponseDTO<EmotionRecordResponseMainDTO> dto =
+                    (EmotionRecordPageResponseDTO<EmotionRecordResponseMainDTO>) cachedResult;
+                emotionRecords.addAll(dto.records());
+            }
+
+            int totalElements = emotionRecords.size();
+            int totalPages = (int) Math.ceil(totalElements / (double) size);
+
+            // 결합된 결과와 새로 계산한 페이징 정보를 이용해 최종 DTO 생성
+            return new EmotionRecordPageResponseDTO<>(emotionRecords, page, totalPages, totalElements);
+        }
+        log.info("캐시 miss 또는 일부 캐시 없음 - keys: {}", keys);
+
+        // Fallback(캐싱 실패 시) 처리 : DB에서 전체 데이터를 조회
+        EmotionRecordPageResponseDTO<EmotionRecordResponseMainDTO> dbResult = fetchFromDB(userId, emotionList, spotifyId, page, size);
+
+        // 조회된 결과를 각 개별 캐시 키에 저장
+        for (String key : keys) {
+            storeInCache(key, dbResult);
+        }
+
+        return dbResult;
+    }
+
+    /**
+     * 주어진 조건(userId, spotifyId, emotions)과 관련된 캐시 키를 모두 무효화(삭제)
+     * 페이지(page)와 사이즈(size)도 결과 캐시에 영향을 미치므로 와일드카드(*)를 사용
+     */
+    public void evictEmotionRecordCache(Long userId, String spotifyId, String emotion) {
+        String keyPattern = generateCacheKeyPattern(userId, spotifyId, emotion);
+
+        // 패턴에 매칭되는 모든 키를 가져옴
+        Set<String> keys = redisTemplate.keys(keyPattern);
+        if (keys != null || !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
+    }
+
+   /**
+    * 캐시 키 패턴 생성 규칙
+    * "user:{userId}:spotifyId:{spotifyId 또는 *}:emotion:{emotion 또는 *}:page:*:size:*"
+    */
+    private String generateCacheKeyPattern(Long userId, String spotifyId, String emotion) {
+        StringBuilder keyPattern = new StringBuilder("user:" + userId);
+
+        // spotifyId가 유효하면 그대로 사용 없으면 와일드 카드(*)
+        if (spotifyId != null && !spotifyId.isBlank()) {
+            keyPattern.append(":spotify:").append(spotifyId);
+        } else {
+            keyPattern.append(":spotify*");
+        }
+
+        // emotion이 유효하면 그대로 사용 없으면 와일드 카드(*)
+        if (emotion != null && !emotion.isEmpty()) {
+            keyPattern.append(":emotion:").append(emotion);
+        } else {
+            keyPattern.append(":emotion:*");
+        }
+
+        // 페이지, 사이즈는 결과에 따라 계속 바뀌므로 와일드카드 사용
+        keyPattern.append(":page:*:size:*");
+
+        return keyPattern.toString();
+    }
+
+    /**
+     * DB에서 데이터를 조회
+     */
+    private EmotionRecordPageResponseDTO<EmotionRecordResponseMainDTO> fetchFromDB(
+            Long userId,
+            List<String> emotions,
+            String spotifyId,
+            int page,
+            int size) {
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+        List<Emotions> emotionEnums = new ArrayList<>();
+        if (emotions != null && !emotions.isEmpty()) {
+            emotionEnums = emotions.stream()
+                    .map(e -> {
+                        try {
+                            return Emotions.valueOf(e.toUpperCase());
+                        } catch (Exception ex) {
+                            throw new IllegalArgumentException("잘못된 감정 값이 포함되어 있습니다: " + e);
+                        }
+                    })
+                    .collect(Collectors.toList());
+        }
+        Page<EmotionRecord> recordsPage = emotionRecordRepository.findByFilters(userId, emotionEnums, spotifyId, pageable);
+        List<EmotionRecordResponseMainDTO> dtoList = recordsPage.getContent().stream()
+                .map(EmotionRecordResponseMainDTO::fromEntity)
+                .collect(Collectors.toList());
+        return EmotionRecordPageResponseDTO.fromPage(recordsPage, dtoList);
+    }
+
+    /**
+     * 캐시에 데이터 저장
+     */
+    private void storeInCache(String key, EmotionRecordPageResponseDTO<EmotionRecordResponseMainDTO> dto) {
+        try {
+            redisTemplate.opsForValue().set(key, dto);
+            log.info("캐시 데이터 저장 성공 - key: {}", key);
+        } catch (Exception e) {
+            log.error("캐시 데이터 저장 중 오류 발생 - key {}: {}", key, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
@@ -168,7 +168,7 @@ public class EmotionRecordService {
     public ResponseResult updateEmotionRecord(Long recordId, EmotionRecordUpdateRequestDTO updateDTO) {
         try {
             // 기존 감정 기록 조회
-            EmotionRecord record = emotionRecordRepository.findByRecordId(recordId)
+            EmotionRecord emotionRecord = emotionRecordRepository.findByRecordId(recordId)
                     .orElseThrow(EmotionRecordNotFoundException::new);
 
             // SpotifyMusic이 DB에 있는지 먼저 확인
@@ -186,14 +186,14 @@ public class EmotionRecordService {
                         return spotifyMusicRepository.save(newMusic);
                     });
 
-            record.updateEmotionRecord(updateDTO.emotion(), updateDTO.comment(), spotifyMusic);
+            emotionRecord.updateEmotionRecord(updateDTO.emotion(), updateDTO.comment(), spotifyMusic);
 
             // 수정된 정보를 Response DTO로 변환
-            EmotionRecordUpdateResponseDTO responseDTO = EmotionRecordUpdateResponseDTO.fromEntity(record);
+            EmotionRecordUpdateResponseDTO responseDTO = EmotionRecordUpdateResponseDTO.fromEntity(emotionRecord);
 
             // 게시글 수정 시, 해당 조건에 맞는 캐시 키 삭제
             emotionRecordCacheService.evictEmotionRecordCache(
-                    record.getUser().getUserId(),
+                    emotionRecord.getUser().getUserId(),
                     updateDTO.spotifyId(),
                     updateDTO.emotion()
             );
@@ -210,16 +210,16 @@ public class EmotionRecordService {
     @Transactional
     public ResponseResult deleteEmotionRecord(Long recordId) {
         try {
-            EmotionRecord record = emotionRecordRepository.findByRecordId(recordId)
+            EmotionRecord emotionRecord = emotionRecordRepository.findByRecordId(recordId)
                     .orElseThrow(EmotionRecordNotFoundException::new);
 
             int deletedCount = emotionRecordRepository.deleteByRecordId(recordId);
 
             // 게시글 삭제 시, 해당 조건에 맞는 캐시 키 삭제
             emotionRecordCacheService.evictEmotionRecordCache(
-                    record.getUser().getUserId(),
-                    record.getSpotifyMusic().getSpotifyId(),
-                    record.getEmotion().name()
+                    emotionRecord.getUser().getUserId(),
+                    emotionRecord.getSpotifyMusic().getSpotifyId(),
+                    emotionRecord.getEmotion().name()
             );
 
             // 삭제할 데이터가 없는 경우

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
@@ -14,7 +14,6 @@ import org.dfbf.soundlink.domain.emotionRecord.repository.EmotionRecordRepositor
 import org.dfbf.soundlink.domain.emotionRecord.repository.SpotifyMusicRepository;
 import org.dfbf.soundlink.domain.user.entity.User;
 import org.dfbf.soundlink.domain.user.repository.UserRepository;
-import org.dfbf.soundlink.global.comm.enums.Emotions;
 import org.dfbf.soundlink.global.exception.ErrorCode;
 import org.dfbf.soundlink.global.exception.ResponseResult;
 import org.springframework.dao.DataAccessException;
@@ -35,6 +34,8 @@ public class EmotionRecordService {
     private final SpotifyMusicRepository spotifyMusicRepository;
     private final EmotionRecordRepository emotionRecordRepository;
     private final UserRepository userRepository;
+
+    private final EmotionRecordCacheService emotionRecordCacheService;
 
     @Transactional
     public ResponseResult saveEmotionRecordWithMusic(Long userId, EmotionRecordRequestDTO request) {
@@ -61,6 +62,13 @@ public class EmotionRecordService {
                     .spotifyMusic(spotifyMusic)
                     .build();
             emotionRecordRepository.save(emotionRecord);
+
+            // 게시글 생성 시, 해당 조건에 맞는 캐시 키 삭제
+            emotionRecordCacheService.evictEmotionRecordCache(
+                    userId,
+                    request.spotifyId(),
+                    request.emotion().name()
+            );
 
             return new ResponseResult(ErrorCode.SUCCESS);
         } catch (UserNotFoundException e) {
@@ -98,33 +106,22 @@ public class EmotionRecordService {
         }
     }
 
+    // 동적 검색 (로그인 사용자를 제외한 EmotionRecord 조회) - 캐시 적용
+    @Transactional(readOnly = true)
     public ResponseResult getEmotionRecordsExcludingUserIdByFilters(Long userId, List<String> emotionList, String spotifyId, int page, int size) {
-        List<Emotions> emotionEnums = null;
         ResponseResult pageValidationResult = validateAndCreatePageable(page, size);
         if (pageValidationResult.getCode() != 200 /*SUCCESS*/) {
             return pageValidationResult;
         }
 
-        Pageable pageable = (Pageable) pageValidationResult.getData();
-
-        if (emotionList != null && !emotionList.isEmpty()) {
-            try {
-                emotionEnums = emotionList.stream()
-                        .map(e -> Emotions.valueOf(e.toUpperCase()))
-                        .toList();
-            } catch (IllegalArgumentException e) {
-                return new ResponseResult(ErrorCode.FAIL_TO_FIND_EMOTION, "잘못된 감정 값이 포함되어 있습니다.");
-            }
-        }
-
         try {
-            Page<EmotionRecord> recordsPage = emotionRecordRepository.findByFilters(userId, emotionEnums, spotifyId, pageable);
-            List<EmotionRecordResponseMainDTO> dtoList = recordsPage.getContent()
-                    .stream()
-                    .map(EmotionRecordResponseMainDTO::fromEntity)
-                    .toList();
-
-            return new ResponseResult(ErrorCode.SUCCESS, EmotionRecordPageResponseDTO.fromPage(recordsPage, dtoList));
+            // EmotionRecordCacheService의 결합 캐시 조회 및 Fallback 처리
+            EmotionRecordPageResponseDTO<EmotionRecordResponseMainDTO> result =
+                    emotionRecordCacheService.getEmotionRecords(userId, emotionList, spotifyId, page, size);
+            return new ResponseResult(ErrorCode.SUCCESS, result);
+        } catch (IllegalArgumentException e) {
+            // 잘못된 감정 값이 포함된 경우
+            return new ResponseResult(ErrorCode.FAIL_TO_FIND_EMOTION, e.getMessage());
         } catch (DataAccessException e) {
             return new ResponseResult(ErrorCode.DB_ERROR, e.getMessage());
         } catch (Exception e) {
@@ -194,6 +191,12 @@ public class EmotionRecordService {
             // 수정된 정보를 Response DTO로 변환
             EmotionRecordUpdateResponseDTO responseDTO = EmotionRecordUpdateResponseDTO.fromEntity(record);
 
+            // 게시글 수정 시, 해당 조건에 맞는 캐시 키 삭제
+            emotionRecordCacheService.evictEmotionRecordCache(
+                    record.getUser().getUserId(),
+                    updateDTO.spotifyId(),
+                    updateDTO.emotion()
+            );
             return new ResponseResult(ErrorCode.SUCCESS, responseDTO);
         } catch (EmotionRecordNotFoundException e) {
             return new ResponseResult(ErrorCode.FAIL_TO_FIND_EMOTION_RECORD, e.getMessage());
@@ -207,7 +210,17 @@ public class EmotionRecordService {
     @Transactional
     public ResponseResult deleteEmotionRecord(Long recordId) {
         try {
+            EmotionRecord record = emotionRecordRepository.findByRecordId(recordId)
+                    .orElseThrow(EmotionRecordNotFoundException::new);
+
             int deletedCount = emotionRecordRepository.deleteByRecordId(recordId);
+
+            // 게시글 삭제 시, 해당 조건에 맞는 캐시 키 삭제
+            emotionRecordCacheService.evictEmotionRecordCache(
+                    record.getUser().getUserId(),
+                    record.getSpotifyMusic().getSpotifyId(),
+                    record.getEmotion().name()
+            );
 
             // 삭제할 데이터가 없는 경우
             if (deletedCount == 0) {

--- a/src/main/java/org/dfbf/soundlink/global/util/CacheKeyGenerator.java
+++ b/src/main/java/org/dfbf/soundlink/global/util/CacheKeyGenerator.java
@@ -1,0 +1,45 @@
+package org.dfbf.soundlink.global.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// 캐시 관련 유틸 클래스
+public class CacheKeyGenerator {
+    /**
+     * 각 emotion에 대해 개별 캐시 키들을 생성 (데이터 캐싱 및 조회)
+     * @param userId 로그인한 유저 ID
+     * @param spotifyId 검색 조건 내 spotifyId (required = false)
+     * @param emotions 검색 조건 내 감정 리스트 (required = false)
+     * @param page 현재 페이지 번호
+     * @param size 페이지 사이즈
+     * @return 생성된 캐시 키 문자열
+     */
+    public static List<String> generateKeysForEmotions(Long userId, String spotifyId, List<String> emotions, int page, int size) {
+        List<String> keys = new ArrayList<>();
+
+        // spotifyId가 유효하면 해당 값을 사용, 아니면 와일드카드(*)를 사용
+        String spotifyPart = (spotifyId != null && !spotifyId.isBlank()) ? spotifyId : "*";
+
+        // 각 emotion에 대해 개별 캐시 키 생성 (캐시 키가 단일 감정만을 포함하도록 함)
+        if (emotions != null && !emotions.isEmpty() /*리스트에 요소를 확인하기 위해 isEmpty 사용*/) {
+            for (String emotion : emotions) {
+                // emotion을 소문자로 변환해서 일관성 유지
+                String emotionPart = emotion.toLowerCase();
+                String key = "user:" + userId
+                        + ":spotifyId:" + spotifyPart
+                        + ":emotion:" + emotionPart
+                        + ":page:" + page + ":size:" + size;
+                keys.add(key);
+            }
+        } else {
+            // emotions가 없을 경우 와일드카드 처리
+            String key = "user:" + userId
+                    + ":spotifyId:" + spotifyPart
+                    + ":emotion:*"
+                    + ":page:" + page + ":size:" + size;
+            keys.add(key);
+        }
+
+        return keys;
+    }
+}

--- a/src/main/java/org/dfbf/soundlink/global/util/CacheKeyGenerator.java
+++ b/src/main/java/org/dfbf/soundlink/global/util/CacheKeyGenerator.java
@@ -1,9 +1,13 @@
 package org.dfbf.soundlink.global.util;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
 import java.util.ArrayList;
 import java.util.List;
 
 // 캐시 관련 유틸 클래스
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CacheKeyGenerator {
     /**
      * 각 emotion에 대해 개별 캐시 키들을 생성 (데이터 캐싱 및 조회)

--- a/src/test/java/org/dfbf/soundlink/domain/emotionRecord/EmotionRecordCacheServiceTest.java
+++ b/src/test/java/org/dfbf/soundlink/domain/emotionRecord/EmotionRecordCacheServiceTest.java
@@ -1,0 +1,193 @@
+package org.dfbf.soundlink.domain.emotionRecord;
+
+import org.dfbf.soundlink.domain.emotionRecord.dto.response.EmotionRecordPageResponseDTO;
+import org.dfbf.soundlink.domain.emotionRecord.dto.response.EmotionRecordResponseMainDTO;
+import org.dfbf.soundlink.domain.emotionRecord.dto.response.SpotifyMusicResponseWithoutVideoIdDTO;
+import org.dfbf.soundlink.domain.emotionRecord.entity.EmotionRecord;
+import org.dfbf.soundlink.domain.emotionRecord.repository.EmotionRecordRepository;
+import org.dfbf.soundlink.domain.emotionRecord.service.EmotionRecordCacheService;
+import org.dfbf.soundlink.global.util.CacheKeyGenerator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class EmotionRecordCacheServiceTest {
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private EmotionRecordRepository emotionRecordRepository;
+
+    @Mock
+    private ValueOperations<String, Object> valueOps;
+
+    @InjectMocks
+    private EmotionRecordCacheService emotionRecordCacheService;
+
+    /**
+     * 캐시가 모두 존재하는 경우, multiGet 결과를 결합하여 반환하는 테스트
+     */
+    @DisplayName("캐시 존재 시, 결과 반환 테스트")
+    @Test
+    public void testGetEmotionRecords_CacheHit() {
+        Long userId = 2L;
+        List<String> emotionList = Arrays.asList("HAPPY", "SAD");
+        String spotifyId = "spotify1";
+        int page = 1;
+        int size = 10;
+
+        // CacheKeyGenerator를 통해 생성된 키 목록
+        List<String> keys = CacheKeyGenerator.generateKeysForEmotions(userId, spotifyId, emotionList, page, size);
+
+        SpotifyMusicResponseWithoutVideoIdDTO testHappy1 = new SpotifyMusicResponseWithoutVideoIdDTO(
+                "S002!",
+                "테스트 제목1",
+                "테스트 가수1",
+                "www.testmusic1.com"
+        );
+
+        SpotifyMusicResponseWithoutVideoIdDTO testHappy2 = new SpotifyMusicResponseWithoutVideoIdDTO(
+                "S0021!",
+                "테스트 제목11",
+                "테스트 가수11",
+                "www.testmusic11.com"
+        );
+
+        SpotifyMusicResponseWithoutVideoIdDTO testSad1 = new SpotifyMusicResponseWithoutVideoIdDTO(
+                "S004!",
+                "테스트 제목2",
+                "테스드 가수2",
+                "www.testmusic2.com"
+        );
+
+        SpotifyMusicResponseWithoutVideoIdDTO testSad2 = new SpotifyMusicResponseWithoutVideoIdDTO(
+                "S0042!",
+                "테스트 제목22",
+                "테스드 가수22",
+                "www.testmusic22.com"
+        );
+
+        // 각 키에 대해 캐시된 DTO 생성 (더미 데이터)
+        List<EmotionRecordResponseMainDTO> recordsHappy = Arrays.asList(
+                new EmotionRecordResponseMainDTO(1001L, "테스트 닉넴0", "HAPPY", testHappy1, "코멘트입니다", LocalDateTime.now().toString()),
+                new EmotionRecordResponseMainDTO(1002L, "테스트 닉넴1", "HAPPY", testHappy2, "코멘트입니다", LocalDateTime.now().toString())
+        );
+
+        EmotionRecordPageResponseDTO<EmotionRecordResponseMainDTO> dtoHappy =
+                new EmotionRecordPageResponseDTO<>(recordsHappy, page, 1, recordsHappy.size());
+
+        List<EmotionRecordResponseMainDTO> recordsSad = Arrays.asList(
+                new EmotionRecordResponseMainDTO(1003L, "테스트 닉넴2", "SAD", testSad1, "코멘트입니다", LocalDateTime.now().toString()),
+                new EmotionRecordResponseMainDTO(1004L, "테스트 닉넴3", "SAD", testSad2, "코멘트입니다", LocalDateTime.now().toString())
+        );
+
+        EmotionRecordPageResponseDTO<EmotionRecordResponseMainDTO> dtoSad =
+                new EmotionRecordPageResponseDTO<>(recordsSad, page, 1, recordsSad.size());
+
+        // multiGet이 각 키에 대해 두 DTO를 반환하도록 설정
+        List<Object> cachedResults = Arrays.asList(dtoHappy, dtoSad);
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        when(valueOps.multiGet(keys)).thenReturn(cachedResults);
+
+        // 테스트 대상 메서드 호출
+        EmotionRecordPageResponseDTO<EmotionRecordResponseMainDTO> result =
+                emotionRecordCacheService.getEmotionRecords(userId, emotionList, spotifyId, page, size);
+
+        // 결합된 결과: 두 개의 리스트가 합쳐짐
+        List<EmotionRecordResponseMainDTO> combined = new ArrayList<>();
+        combined.addAll(recordsHappy);
+        combined.addAll(recordsSad);
+        int expectedTotalElements = combined.size();
+        int expectedTotalPages = (int) Math.ceil(expectedTotalElements / (double) size);
+
+        assertNotNull(result);
+        assertEquals(expectedTotalElements, result.totalElements());
+        assertEquals(expectedTotalPages, result.totalPages());
+        // combined 리스트의 내용과 result.records() 내용이 같은지 확인
+        assertEquals(combined.size(), result.records().size());
+    }
+
+    /**
+     * 캐시 미스(또는 일부 캐시 누락) 시, DB에서 데이터를 조회하여 반환하는 Fallback 테스트
+     */
+    @DisplayName("캐시 누락 시, DB에서 조회 후 반환 테스트")
+    @Test
+    public void testGetEmotionRecords_CacheMiss() {
+        Long userId = 2L;
+        List<String> emotionList = Arrays.asList("HAPPY", "SAD");
+        String spotifyId = "spotify1";
+        int page = 1;
+        int size = 10;
+
+        List<String> keys = CacheKeyGenerator.generateKeysForEmotions(userId, spotifyId, emotionList, page, size);
+
+        // multiGet이 null을 반환하여 캐시 미스 처리
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        when(valueOps.multiGet(keys)).thenReturn(null);
+
+        // DB 조회를 위한 더미 데이터 설정
+        List<EmotionRecord> dummyRecords = new ArrayList<>();
+        // 필요한 경우 dummyRecords에 EmotionRecord 객체들을 추가
+        Pageable pageable = PageRequest.of(0, size, Sort.by("createdAt").descending());
+        Page<EmotionRecord> pageResult = new PageImpl<>(dummyRecords, pageable, 0);
+        when(emotionRecordRepository.findByFilters(eq(userId), anyList(), eq(spotifyId), any(Pageable.class)))
+                .thenReturn(pageResult);
+
+        // DB 조회 결과가 빈 리스트인 경우에 대한 DTO 생성
+        EmotionRecordPageResponseDTO<EmotionRecordResponseMainDTO> expectedDto =
+                EmotionRecordPageResponseDTO.fromPage(pageResult, Collections.emptyList());
+
+        // 테스트 대상 메서드 호출
+        EmotionRecordPageResponseDTO<EmotionRecordResponseMainDTO> result =
+                emotionRecordCacheService.getEmotionRecords(userId, emotionList, spotifyId, page, size);
+
+        assertNotNull(result);
+        assertEquals(expectedDto.totalElements(), result.totalElements());
+        assertEquals(expectedDto.records().size(), result.records().size());
+
+        // multiGet이 캐시 미스이므로, DB 조회 후 각 키에 대해 캐시에 저장되는지 검증
+        for (String key : keys) {
+            verify(redisTemplate.opsForValue(), atLeastOnce()).set(eq(key), any());
+        }
+    }
+
+    /**
+     * 주어진 조건에 맞는 키 패턴에 해당하는 캐시 키들을 삭제하는지 검증
+     */
+    @DisplayName("키 삭제 테스트")
+    @Test
+    public void testEvictEmotionRecordCache() {
+        Long userId = 1L;
+        String spotifyId = "spotify1";
+        String emotion = "happy";
+
+        // 캐시 키 패턴 생성 (테스트용)
+        String keyPattern = "user:" + userId + ":spotify:" + spotifyId + ":emotion:" + emotion + ":page:*:size:*";
+        Set<String> keys = new HashSet<>(Arrays.asList("user:1:spotify:spotify1:emotion:happy:page:1:size:10",
+                "user:1:spotify:*:emotion:sad:page:1:size:10"));
+        when(redisTemplate.keys(keyPattern)).thenReturn(keys);
+
+        // 캐시 삭제 시, 리턴값을 true로 설정
+        when(redisTemplate.delete(keys)).thenReturn(1L);
+
+        // 테스트 대상 메서드 호출
+        emotionRecordCacheService.evictEmotionRecordCache(userId, spotifyId, emotion);
+
+        // verify: redisTemplate.delete가 호출되어 키들이 삭제되었는지 확인
+        verify(redisTemplate, times(1)).delete(keys);
+    }
+}

--- a/src/test/java/org/dfbf/soundlink/domain/emotionRecord/EmotionRecordCacheServiceTest.java
+++ b/src/test/java/org/dfbf/soundlink/domain/emotionRecord/EmotionRecordCacheServiceTest.java
@@ -25,7 +25,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class EmotionRecordCacheServiceTest {
+class EmotionRecordCacheServiceTest {
     @Mock
     private RedisTemplate<String, Object> redisTemplate;
 

--- a/src/test/java/org/dfbf/soundlink/domain/emotionRecord/EmotionRecordCacheServiceTest.java
+++ b/src/test/java/org/dfbf/soundlink/domain/emotionRecord/EmotionRecordCacheServiceTest.java
@@ -43,7 +43,7 @@ public class EmotionRecordCacheServiceTest {
      */
     @DisplayName("캐시 존재 시, 결과 반환 테스트")
     @Test
-    public void testGetEmotionRecords_CacheHit() {
+    void testGetEmotionRecords_CacheHit() {
         Long userId = 2L;
         List<String> emotionList = Arrays.asList("HAPPY", "SAD");
         String spotifyId = "spotify1";
@@ -126,7 +126,7 @@ public class EmotionRecordCacheServiceTest {
      */
     @DisplayName("캐시 누락 시, DB에서 조회 후 반환 테스트")
     @Test
-    public void testGetEmotionRecords_CacheMiss() {
+    void testGetEmotionRecords_CacheMiss() {
         Long userId = 2L;
         List<String> emotionList = Arrays.asList("HAPPY", "SAD");
         String spotifyId = "spotify1";
@@ -170,7 +170,7 @@ public class EmotionRecordCacheServiceTest {
      */
     @DisplayName("키 삭제 테스트")
     @Test
-    public void testEvictEmotionRecordCache() {
+    void testEvictEmotionRecordCache() {
         Long userId = 1L;
         String spotifyId = "spotify1";
         String emotion = "happy";

--- a/src/test/java/org/dfbf/soundlink/domain/emotionRecord/EmotionRecordServiceTest.java
+++ b/src/test/java/org/dfbf/soundlink/domain/emotionRecord/EmotionRecordServiceTest.java
@@ -6,6 +6,7 @@ import org.dfbf.soundlink.domain.emotionRecord.entity.EmotionRecord;
 import org.dfbf.soundlink.domain.emotionRecord.entity.SpotifyMusic;
 import org.dfbf.soundlink.domain.emotionRecord.repository.EmotionRecordRepository;
 import org.dfbf.soundlink.domain.emotionRecord.repository.SpotifyMusicRepository;
+import org.dfbf.soundlink.domain.emotionRecord.service.EmotionRecordCacheService;
 import org.dfbf.soundlink.domain.emotionRecord.service.EmotionRecordService;
 import org.dfbf.soundlink.domain.user.entity.User;
 import org.dfbf.soundlink.domain.user.repository.UserRepository;
@@ -30,6 +31,8 @@ class EmotionRecordServiceTest {
     @InjectMocks
     private EmotionRecordService emotionRecordService;
     @Mock
+    private EmotionRecordCacheService emotionRecordCacheService;
+    @Mock
     private EmotionRecordRepository emotionRecordRepository;
     @Mock
     private SpotifyMusicRepository spotifyMusicRepository;
@@ -37,13 +40,20 @@ class EmotionRecordServiceTest {
     private UserRepository userRepository;
 
 
+
+
     @DisplayName("감정기록 작성(제목,가수,앨범,스포티파이아이디,감정,멘트):성공")
     @Test
     void saveEmotionRecordWithMusic_SUCCESS() {
+
+        // 각 테스트 전에 캐시 제거 호출은 아무 동작도 하지 않도록 설정
+        doNothing().when(emotionRecordCacheService)
+                .evictEmotionRecordCache(any(), any(), any());
+
         // given
         Long userId = 1L;
         EmotionRecordRequestDTO requestDTO = new EmotionRecordRequestDTO(
-                "spotify1233", "New videoId", "New Title", "New Artist", "New Image",HAPPY, "Test comment"
+                "spotify1233", "New videoId", "New Title", "New Artist", "New Image", HAPPY, "Test comment"
         );
 
         User mockUser = mock(User.class);
@@ -67,14 +77,38 @@ class EmotionRecordServiceTest {
     @DisplayName("감정기록 삭제:성공")
     @Test
     void deleteEmotionRecord_SUCCESS() {
-        //given
+        // given
         Long recordId = 1L;
-        when(emotionRecordRepository.deleteByRecordId(recordId)).thenReturn(1);//삭제된 레코드 수 1개
-        //when
+
+        // 모의 User, SpotifyMusic, Emotions 생성 및 스텁 처리
+        User mockUser = mock(User.class);
+        when(mockUser.getUserId()).thenReturn(100L);  // 예시 값
+
+        SpotifyMusic mockMusic = mock(SpotifyMusic.class);
+        when(mockMusic.getSpotifyId()).thenReturn("spotify123");
+
+        EmotionRecord mockRecord = mock(EmotionRecord.class);
+
+        // 실제 존재하는 EmotionRecord 모의 객체 (캐싱제거 처리로 추가)
+        when(mockRecord.getUser()).thenReturn(mockUser);
+        when(mockRecord.getSpotifyMusic()).thenReturn(mockMusic);
+        when(mockRecord.getEmotion()).thenReturn(Emotions.HAPPY);
+
+        when(emotionRecordRepository.findByRecordId(recordId)).thenReturn(Optional.of(mockRecord));
+        when(emotionRecordRepository.deleteByRecordId(recordId)).thenReturn(1); // 삭제된 레코드 수 1개
+
+        // 캐시 제거 호출은 아무 동작도 하지 않도록 설정
+        doNothing().when(emotionRecordCacheService)
+                .evictEmotionRecordCache(any(), any(), any());
+
+        // when
         ResponseResult result = emotionRecordService.deleteEmotionRecord(recordId);
-        //then
-        assertEquals(200,result.getCode());
+
+        // then
+        assertEquals(200, result.getCode());
+        verify(emotionRecordRepository).findByRecordId(recordId);
         verify(emotionRecordRepository).deleteByRecordId(recordId);
+        verify(emotionRecordCacheService).evictEmotionRecordCache(any(), any(), any());
     }
 
 
@@ -96,6 +130,11 @@ class EmotionRecordServiceTest {
     @Test
     @DisplayName("감정 기록 수정 성공 테스트")
     void updateEmotionRecord_Success() {
+
+        // 각 테스트 전에 캐시 제거 호출은 아무 동작도 하지 않도록 설정
+        doNothing().when(emotionRecordCacheService)
+                .evictEmotionRecordCache(any(), any(), any());
+
         // given
         Long recordId = 1L;
         EmotionRecordUpdateRequestDTO updateDTO = new EmotionRecordUpdateRequestDTO(

--- a/src/test/java/org/dfbf/soundlink/domain/emotionRecord/EmotionRecordServiceTest.java
+++ b/src/test/java/org/dfbf/soundlink/domain/emotionRecord/EmotionRecordServiceTest.java
@@ -1,4 +1,4 @@
-package org.dfbf.soundlink.domain.emtionRecord;
+package org.dfbf.soundlink.domain.emotionRecord;
 
 import org.dfbf.soundlink.domain.emotionRecord.dto.request.EmotionRecordRequestDTO;
 import org.dfbf.soundlink.domain.emotionRecord.dto.request.EmotionRecordUpdateRequestDTO;
@@ -10,7 +10,6 @@ import org.dfbf.soundlink.domain.emotionRecord.service.EmotionRecordService;
 import org.dfbf.soundlink.domain.user.entity.User;
 import org.dfbf.soundlink.domain.user.repository.UserRepository;
 import org.dfbf.soundlink.global.comm.enums.Emotions;
-import org.dfbf.soundlink.global.exception.ErrorCode;
 import org.dfbf.soundlink.global.exception.ResponseResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,7 +17,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 
 import java.util.Optional;

--- a/src/test/java/org/dfbf/soundlink/domain/emotionRecord/EmotionRecordServiceTest.java
+++ b/src/test/java/org/dfbf/soundlink/domain/emotionRecord/EmotionRecordServiceTest.java
@@ -40,8 +40,6 @@ class EmotionRecordServiceTest {
     private UserRepository userRepository;
 
 
-
-
     @DisplayName("감정기록 작성(제목,가수,앨범,스포티파이아이디,감정,멘트):성공")
     @Test
     void saveEmotionRecordWithMusic_SUCCESS() {
@@ -111,21 +109,6 @@ class EmotionRecordServiceTest {
         verify(emotionRecordCacheService).evictEmotionRecordCache(any(), any(), any());
     }
 
-
-//    @DisplayName("감정기록 DB오류 : 실패")
-//    @Test
-//    void deleteEmotionRecord_DataAccessException() {
-//        // given
-//        Long recordId = 1L;
-//        when(emotionRecordRepository.deleteByRecordId(recordId)).thenThrow(new DataAccessException("Database error") {});
-//
-//        // when
-//        ResponseResult result = emotionRecordService.deleteEmotionRecord(recordId);
-//
-//        // then
-//        assertEquals(ErrorCode.DB_ERROR, result.getCode());
-//        assertEquals("Database error", result.getMessage());
-//    }
 
     @Test
     @DisplayName("감정 기록 수정 성공 테스트")


### PR DESCRIPTION
감정 기록 전체조회 부분 Redis 캐싱 적용 및 테스트 코드 작성

- 게시글 생성, 수정, 삭제 될 때 즉시 관련 캐시를 무효화하거나 업데이트 하도록 함
- 각 캐시 키가 단일 감정 값을 포함하도록 설계함 (검색 시, HAPPY와 SAD 검색하면 HAPPY와 SAD 에 대한 각각의 키가 생성)
- 조회 시 감정 값 2개 이상인 경우, 단일 감정 값을 가진 키들을 합쳐서 한 번에 반환하도록 함

