### PR TITLE
fix: 감정 기록 삭제가 안되는 버그 수정

### DIFF
--- a/src/main/java/org/dfbf/soundlink/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/org/dfbf/soundlink/domain/chat/repository/ChatRoomRepository.java
@@ -5,6 +5,9 @@ import org.dfbf.soundlink.domain.emotionRecord.entity.EmotionRecord;
 import org.dfbf.soundlink.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatRoomCustomRepository {
     boolean existsByRequestUserIdAndRecordId(User requestUserId, EmotionRecord recordId);
+    List<ChatRoom> findByRecordId(EmotionRecord recordId);
 }

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
@@ -2,6 +2,8 @@ package org.dfbf.soundlink.domain.emotionRecord.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.dfbf.soundlink.domain.chat.entity.ChatRoom;
+import org.dfbf.soundlink.domain.chat.repository.ChatRoomRepository;
 import org.dfbf.soundlink.domain.emotionRecord.dto.request.EmotionRecordRequestDTO;
 import org.dfbf.soundlink.domain.emotionRecord.dto.request.EmotionRecordUpdateRequestDTO;
 import org.dfbf.soundlink.domain.emotionRecord.dto.response.*;
@@ -36,6 +38,7 @@ public class EmotionRecordService {
     private final UserRepository userRepository;
 
     private final EmotionRecordCacheService emotionRecordCacheService;
+    private final ChatRoomRepository chatRoomRepository;
 
     @Transactional
     public ResponseResult saveEmotionRecordWithMusic(Long userId, EmotionRecordRequestDTO request) {
@@ -214,7 +217,17 @@ public class EmotionRecordService {
             EmotionRecord emotionRecord = emotionRecordRepository.findByRecordId(recordId)
                     .orElseThrow(EmotionRecordNotFoundException::new);
 
+            // 해당 EmotionRecord를 참조하는 채팅방 조회
+            List<ChatRoom> chatRooms = chatRoomRepository.findByRecordId(emotionRecord);
+
+            // 채팅방이 존재하면 모두 삭제 후 삭제 내용을 즉시 반영
+            if (chatRooms != null && !chatRooms.isEmpty()) {
+                chatRoomRepository.deleteAll(chatRooms);
+                chatRoomRepository.flush(); // 즉시 DB에 반영
+            }
+
             int deletedCount = emotionRecordRepository.deleteByRecordId(recordId);
+            emotionRecordRepository.flush(); // 즉시 DB에 반영
 
             // 게시글 삭제 시, 해당 조건에 맞는 캐시 키 삭제
             emotionRecordCacheService.evictEmotionRecordCache(

--- a/src/test/java/org/dfbf/soundlink/domain/emotionRecord/EmotionRecordServiceTest.java
+++ b/src/test/java/org/dfbf/soundlink/domain/emotionRecord/EmotionRecordServiceTest.java
@@ -1,5 +1,7 @@
 package org.dfbf.soundlink.domain.emotionRecord;
 
+import org.dfbf.soundlink.domain.chat.entity.ChatRoom;
+import org.dfbf.soundlink.domain.chat.repository.ChatRoomRepository;
 import org.dfbf.soundlink.domain.emotionRecord.dto.request.EmotionRecordRequestDTO;
 import org.dfbf.soundlink.domain.emotionRecord.dto.request.EmotionRecordUpdateRequestDTO;
 import org.dfbf.soundlink.domain.emotionRecord.entity.EmotionRecord;
@@ -20,6 +22,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.dfbf.soundlink.global.comm.enums.Emotions.HAPPY;
@@ -32,6 +36,8 @@ class EmotionRecordServiceTest {
     private EmotionRecordService emotionRecordService;
     @Mock
     private EmotionRecordCacheService emotionRecordCacheService;
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
     @Mock
     private EmotionRecordRepository emotionRecordRepository;
     @Mock
@@ -92,6 +98,13 @@ class EmotionRecordServiceTest {
         when(mockRecord.getSpotifyMusic()).thenReturn(mockMusic);
         when(mockRecord.getEmotion()).thenReturn(Emotions.HAPPY);
 
+        // 채팅방 모의 객체 생성 (해당 EmotionRecord를 참조하는 채팅방 존재)
+        ChatRoom mockChatRoom = mock(ChatRoom.class);
+        List<ChatRoom> mockChatRooms = Collections.singletonList(mockChatRoom);
+
+        // 스텁 설정
+        when(chatRoomRepository.findByRecordId(mockRecord))
+                .thenReturn(mockChatRooms);
         when(emotionRecordRepository.findByRecordId(recordId)).thenReturn(Optional.of(mockRecord));
         when(emotionRecordRepository.deleteByRecordId(recordId)).thenReturn(1); // 삭제된 레코드 수 1개
 
@@ -105,7 +118,11 @@ class EmotionRecordServiceTest {
         // then
         assertEquals(200, result.getCode());
         verify(emotionRecordRepository).findByRecordId(recordId);
+        verify(chatRoomRepository).findByRecordId(mockRecord);
+        verify(chatRoomRepository).deleteAll(mockChatRooms);
+        verify(chatRoomRepository).flush();
         verify(emotionRecordRepository).deleteByRecordId(recordId);
+        verify(emotionRecordRepository).flush();
         verify(emotionRecordCacheService).evictEmotionRecordCache(any(), any(), any());
     }
 


### PR DESCRIPTION
- ChatRoom에서 EmotionRecord @ManyToOne 관계로 참조해서 감정 기록 삭제 시, 에러 발생되는 것으로 확인 후 수정