### PR TITLE
fix/emotionRecord/main

### DIFF
--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
@@ -16,6 +16,7 @@ import org.dfbf.soundlink.domain.emotionRecord.repository.EmotionRecordRepositor
 import org.dfbf.soundlink.domain.emotionRecord.repository.SpotifyMusicRepository;
 import org.dfbf.soundlink.domain.user.entity.User;
 import org.dfbf.soundlink.domain.user.repository.UserRepository;
+import org.dfbf.soundlink.global.comm.enums.Emotions;
 import org.dfbf.soundlink.global.exception.ErrorCode;
 import org.dfbf.soundlink.global.exception.ResponseResult;
 import org.springframework.dao.DataAccessException;
@@ -37,7 +38,7 @@ public class EmotionRecordService {
     private final EmotionRecordRepository emotionRecordRepository;
     private final UserRepository userRepository;
 
-    private final EmotionRecordCacheService emotionRecordCacheService;
+    // private final EmotionRecordCacheService emotionRecordCacheService;
     private final ChatRoomRepository chatRoomRepository;
 
     @Transactional
@@ -67,12 +68,12 @@ public class EmotionRecordService {
                     .build();
             emotionRecordRepository.save(emotionRecord);
 
-            // 게시글 생성 시, 해당 조건에 맞는 캐시 키 삭제
+/*            // 게시글 생성 시, 해당 조건에 맞는 캐시 키 삭제
             emotionRecordCacheService.evictEmotionRecordCache(
                     userId,
                     request.spotifyId(),
                     request.emotion().name()
-            );
+            );*/
 
             return new ResponseResult(ErrorCode.SUCCESS);
         } catch (UserNotFoundException e) {
@@ -110,22 +111,33 @@ public class EmotionRecordService {
         }
     }
 
-    // 동적 검색 (로그인 사용자를 제외한 EmotionRecord 조회) - 캐시 적용
-    @Transactional(readOnly = true)
     public ResponseResult getEmotionRecordsExcludingUserIdByFilters(Long userId, List<String> emotionList, String spotifyId, int page, int size) {
+        List<Emotions> emotionEnums = null;
         ResponseResult pageValidationResult = validateAndCreatePageable(page, size);
         if (pageValidationResult.getCode() != 200 /*SUCCESS*/) {
             return pageValidationResult;
         }
 
+        Pageable pageable = (Pageable) pageValidationResult.getData();
+
+        if (emotionList != null && !emotionList.isEmpty()) {
+            try {
+                emotionEnums = emotionList.stream()
+                        .map(e -> Emotions.valueOf(e.toUpperCase()))
+                        .toList();
+            } catch (IllegalArgumentException e) {
+                return new ResponseResult(ErrorCode.FAIL_TO_FIND_EMOTION, "잘못된 감정 값이 포함되어 있습니다.");
+            }
+        }
+
         try {
-            // EmotionRecordCacheService의 결합 캐시 조회 및 Fallback 처리
-            EmotionRecordPageResponseDTO<EmotionRecordResponseMainDTO> result =
-                    emotionRecordCacheService.getEmotionRecords(userId, emotionList, spotifyId, page, size);
-            return new ResponseResult(ErrorCode.SUCCESS, result);
-        } catch (IllegalArgumentException e) {
-            // 잘못된 감정 값이 포함된 경우
-            return new ResponseResult(ErrorCode.FAIL_TO_FIND_EMOTION, e.getMessage());
+            Page<EmotionRecord> recordsPage = emotionRecordRepository.findByFilters(userId, emotionEnums, spotifyId, pageable);
+            List<EmotionRecordResponseMainDTO> dtoList = recordsPage.getContent()
+                    .stream()
+                    .map(EmotionRecordResponseMainDTO::fromEntity)
+                    .toList();
+
+            return new ResponseResult(ErrorCode.SUCCESS, EmotionRecordPageResponseDTO.fromPage(recordsPage, dtoList));
         } catch (DataAccessException e) {
             return new ResponseResult(ErrorCode.DB_ERROR, e.getMessage());
         } catch (Exception e) {
@@ -195,12 +207,12 @@ public class EmotionRecordService {
             // 수정된 정보를 Response DTO로 변환
             EmotionRecordUpdateResponseDTO responseDTO = EmotionRecordUpdateResponseDTO.fromEntity(emotionRecord);
 
-            // 게시글 수정 시, 해당 조건에 맞는 캐시 키 삭제
+/*            // 게시글 수정 시, 해당 조건에 맞는 캐시 키 삭제
             emotionRecordCacheService.evictEmotionRecordCache(
                     emotionRecord.getUser().getUserId(),
                     updateDTO.spotifyId(),
                     updateDTO.emotion()
-            );
+            );*/
             return new ResponseResult(ErrorCode.SUCCESS, responseDTO);
         } catch (EmotionRecordNotFoundException e) {
             return new ResponseResult(ErrorCode.FAIL_TO_FIND_EMOTION_RECORD, e.getMessage());
@@ -229,12 +241,12 @@ public class EmotionRecordService {
             int deletedCount = emotionRecordRepository.deleteByRecordId(recordId);
             emotionRecordRepository.flush(); // 즉시 DB에 반영
 
-            // 게시글 삭제 시, 해당 조건에 맞는 캐시 키 삭제
+/*            // 게시글 삭제 시, 해당 조건에 맞는 캐시 키 삭제
             emotionRecordCacheService.evictEmotionRecordCache(
                     emotionRecord.getUser().getUserId(),
                     emotionRecord.getSpotifyMusic().getSpotifyId(),
                     emotionRecord.getEmotion().name()
-            );
+            );*/
 
             // 삭제할 데이터가 없는 경우
             if (deletedCount == 0) {

--- a/src/main/java/org/dfbf/soundlink/domain/user/service/KakaoAuthService.java
+++ b/src/main/java/org/dfbf/soundlink/domain/user/service/KakaoAuthService.java
@@ -128,7 +128,7 @@ public class KakaoAuthService {
 
         // 닉네임이 중복되지 않을 때까지 반복
         while (userRepository.existsByNickname(newNickname)) {
-            newNickname = baseNickname + "_" + suffix;
+            newNickname = "k" + suffix;
             suffix++;
         }
         return newNickname;

--- a/src/test/java/org/dfbf/soundlink/domain/emotionRecord/EmotionRecordServiceTest.java
+++ b/src/test/java/org/dfbf/soundlink/domain/emotionRecord/EmotionRecordServiceTest.java
@@ -1,6 +1,5 @@
 package org.dfbf.soundlink.domain.emotionRecord;
 
-import org.dfbf.soundlink.domain.chat.entity.ChatRoom;
 import org.dfbf.soundlink.domain.chat.repository.ChatRoomRepository;
 import org.dfbf.soundlink.domain.emotionRecord.dto.request.EmotionRecordRequestDTO;
 import org.dfbf.soundlink.domain.emotionRecord.dto.request.EmotionRecordUpdateRequestDTO;
@@ -8,7 +7,6 @@ import org.dfbf.soundlink.domain.emotionRecord.entity.EmotionRecord;
 import org.dfbf.soundlink.domain.emotionRecord.entity.SpotifyMusic;
 import org.dfbf.soundlink.domain.emotionRecord.repository.EmotionRecordRepository;
 import org.dfbf.soundlink.domain.emotionRecord.repository.SpotifyMusicRepository;
-import org.dfbf.soundlink.domain.emotionRecord.service.EmotionRecordCacheService;
 import org.dfbf.soundlink.domain.emotionRecord.service.EmotionRecordService;
 import org.dfbf.soundlink.domain.user.entity.User;
 import org.dfbf.soundlink.domain.user.repository.UserRepository;
@@ -23,7 +21,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 
 import static org.dfbf.soundlink.global.comm.enums.Emotions.HAPPY;
@@ -35,25 +32,18 @@ class EmotionRecordServiceTest {
     @InjectMocks
     private EmotionRecordService emotionRecordService;
     @Mock
-    private EmotionRecordCacheService emotionRecordCacheService;
-    @Mock
-    private ChatRoomRepository chatRoomRepository;
-    @Mock
     private EmotionRecordRepository emotionRecordRepository;
     @Mock
     private SpotifyMusicRepository spotifyMusicRepository;
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
 
 
-    @DisplayName("감정기록 작성(제목,가수,앨범,스포티파이아이디,감정,멘트):성공")
+    @DisplayName("감정기록 작성(제목, 가수, 앨범, 스포티파이 아이디, 감정, 멘트): 성공")
     @Test
     void saveEmotionRecordWithMusic_SUCCESS() {
-
-        // 각 테스트 전에 캐시 제거 호출은 아무 동작도 하지 않도록 설정
-        doNothing().when(emotionRecordCacheService)
-                .evictEmotionRecordCache(any(), any(), any());
-
         // given
         Long userId = 1L;
         EmotionRecordRequestDTO requestDTO = new EmotionRecordRequestDTO(
@@ -61,93 +51,63 @@ class EmotionRecordServiceTest {
         );
 
         User mockUser = mock(User.class);
-        SpotifyMusic newSpotifyMusic = new SpotifyMusic(requestDTO.spotifyId(), requestDTO.title(), requestDTO.artist(), requestDTO.albumImage(),requestDTO.videoId());
-        EmotionRecord newEmotionRecord = mock(EmotionRecord.class);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(spotifyMusicRepository.findBySpotifyId(requestDTO.spotifyId())).thenReturn(Optional.empty());
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser)); // 사용자 조회 성공
-        when(spotifyMusicRepository.save(any(SpotifyMusic.class))).thenReturn(newSpotifyMusic); // 음악 저장
-        when(emotionRecordRepository.save(any(EmotionRecord.class))).thenReturn(newEmotionRecord); // 감정 기록 저장
+        SpotifyMusic newSpotifyMusic = SpotifyMusic.builder()
+                .spotifyId(requestDTO.spotifyId())
+                .videoId(requestDTO.videoId())
+                .title(requestDTO.title())
+                .artist(requestDTO.artist())
+                .albumImage(requestDTO.albumImage())
+                .build();
+        when(spotifyMusicRepository.save(any(SpotifyMusic.class))).thenReturn(newSpotifyMusic);
+
+        EmotionRecord newEmotionRecord = mock(EmotionRecord.class);
+        when(emotionRecordRepository.save(any(EmotionRecord.class))).thenReturn(newEmotionRecord);
 
         // when
         ResponseResult result = emotionRecordService.saveEmotionRecordWithMusic(userId, requestDTO);
 
         // then
         assertEquals(HttpStatus.OK.value(), result.getCode());
-        verify(spotifyMusicRepository).save(any(SpotifyMusic.class)); // 음악이 저장되었는지 검증
-        verify(emotionRecordRepository).save(any(EmotionRecord.class)); // 감정 기록이 저장되었는지 검증
+        verify(spotifyMusicRepository).save(any(SpotifyMusic.class));
+        verify(emotionRecordRepository).save(any(EmotionRecord.class));
     }
 
-    //감정기록 삭제 : 성공
-    @DisplayName("감정기록 삭제:성공")
+    @DisplayName("감정기록 삭제: 성공")
     @Test
     void deleteEmotionRecord_SUCCESS() {
         // given
         Long recordId = 1L;
-
-        // 모의 User, SpotifyMusic, Emotions 생성 및 스텁 처리
-        User mockUser = mock(User.class);
-        when(mockUser.getUserId()).thenReturn(100L);  // 예시 값
-
-        SpotifyMusic mockMusic = mock(SpotifyMusic.class);
-        when(mockMusic.getSpotifyId()).thenReturn("spotify123");
-
+        // delete 호출 전, 해당 record가 존재함을 확인하기 위한 stub 추가
         EmotionRecord mockRecord = mock(EmotionRecord.class);
-
-        // 실제 존재하는 EmotionRecord 모의 객체 (캐싱제거 처리로 추가)
-        when(mockRecord.getUser()).thenReturn(mockUser);
-        when(mockRecord.getSpotifyMusic()).thenReturn(mockMusic);
-        when(mockRecord.getEmotion()).thenReturn(Emotions.HAPPY);
-
-        // 채팅방 모의 객체 생성 (해당 EmotionRecord를 참조하는 채팅방 존재)
-        ChatRoom mockChatRoom = mock(ChatRoom.class);
-        List<ChatRoom> mockChatRooms = Collections.singletonList(mockChatRoom);
-
-        // 스텁 설정
-        when(chatRoomRepository.findByRecordId(mockRecord))
-                .thenReturn(mockChatRooms);
         when(emotionRecordRepository.findByRecordId(recordId)).thenReturn(Optional.of(mockRecord));
-        when(emotionRecordRepository.deleteByRecordId(recordId)).thenReturn(1); // 삭제된 레코드 수 1개
-
-        // 캐시 제거 호출은 아무 동작도 하지 않도록 설정
-        doNothing().when(emotionRecordCacheService)
-                .evictEmotionRecordCache(any(), any(), any());
+        // 채팅방 조회 시 빈 리스트 반환 (삭제할 채팅방 없음)
+        when(chatRoomRepository.findByRecordId(mockRecord)).thenReturn(Collections.emptyList());
+        when(emotionRecordRepository.deleteByRecordId(recordId)).thenReturn(1);
 
         // when
         ResponseResult result = emotionRecordService.deleteEmotionRecord(recordId);
 
         // then
-        assertEquals(200, result.getCode());
-        verify(emotionRecordRepository).findByRecordId(recordId);
-        verify(chatRoomRepository).findByRecordId(mockRecord);
-        verify(chatRoomRepository).deleteAll(mockChatRooms);
-        verify(chatRoomRepository).flush();
+        assertEquals(HttpStatus.OK.value(), result.getCode());
         verify(emotionRecordRepository).deleteByRecordId(recordId);
-        verify(emotionRecordRepository).flush();
-        verify(emotionRecordCacheService).evictEmotionRecordCache(any(), any(), any());
     }
 
-
     @Test
-    @DisplayName("감정 기록 수정 성공 테스트")
+    @DisplayName("감정 기록 수정: 성공")
     void updateEmotionRecord_Success() {
-
-        // 각 테스트 전에 캐시 제거 호출은 아무 동작도 하지 않도록 설정
-        doNothing().when(emotionRecordCacheService)
-                .evictEmotionRecordCache(any(), any(), any());
-
         // given
         Long recordId = 1L;
         EmotionRecordUpdateRequestDTO updateDTO = new EmotionRecordUpdateRequestDTO(
-                "spotify1233", "New videoId", "New Title", "New Artist", "New Image","HAPPY", "Test comment"
+                "spotify1233", "New videoId", "New Title", "New Artist", "New Image", "HAPPY", "Test comment"
         );
 
-        // 기존 감정 기록 및 음악 정보
-        SpotifyMusic existingMusic = new SpotifyMusic("spotify123", "1234" ,"Old Title", "Old Artist", "Old Image");
-        EmotionRecord existingRecord = new EmotionRecord(
-                mock(User.class), Emotions.SAD, "Old Comment", existingMusic
-        );
+        SpotifyMusic existingMusic = new SpotifyMusic("spotify1233", "Old videoId", "Old Title", "Old Artist", "Old Image");
+        EmotionRecord existingRecord = new EmotionRecord(mock(User.class), Emotions.SAD, "Old Comment", existingMusic);
 
-        // 기존 감정 기록 조회
+        // 기존 감정 기록 조회 stub
         when(emotionRecordRepository.findByRecordId(recordId)).thenReturn(Optional.of(existingRecord));
         when(spotifyMusicRepository.findBySpotifyId(updateDTO.spotifyId())).thenReturn(Optional.of(existingMusic));
 
@@ -155,12 +115,9 @@ class EmotionRecordServiceTest {
         ResponseResult result = emotionRecordService.updateEmotionRecord(recordId, updateDTO);
 
         // then
-        assertEquals(200, result.getCode());
+        assertEquals(HttpStatus.OK.value(), result.getCode());
         verify(emotionRecordRepository).findByRecordId(recordId);
         verify(spotifyMusicRepository).findBySpotifyId(updateDTO.spotifyId());
         verify(emotionRecordRepository, never()).save(any()); // update는 save 호출 안 함
     }
-
-
-
 }

--- a/src/test/java/org/dfbf/soundlink/domain/emotionRecord/EmotionRecordServiceTest_Cache.java
+++ b/src/test/java/org/dfbf/soundlink/domain/emotionRecord/EmotionRecordServiceTest_Cache.java
@@ -1,0 +1,166 @@
+package org.dfbf.soundlink.domain.emotionRecord;
+
+import org.dfbf.soundlink.domain.chat.entity.ChatRoom;
+import org.dfbf.soundlink.domain.chat.repository.ChatRoomRepository;
+import org.dfbf.soundlink.domain.emotionRecord.dto.request.EmotionRecordRequestDTO;
+import org.dfbf.soundlink.domain.emotionRecord.dto.request.EmotionRecordUpdateRequestDTO;
+import org.dfbf.soundlink.domain.emotionRecord.entity.EmotionRecord;
+import org.dfbf.soundlink.domain.emotionRecord.entity.SpotifyMusic;
+import org.dfbf.soundlink.domain.emotionRecord.repository.EmotionRecordRepository;
+import org.dfbf.soundlink.domain.emotionRecord.repository.SpotifyMusicRepository;
+import org.dfbf.soundlink.domain.emotionRecord.service.EmotionRecordCacheService;
+import org.dfbf.soundlink.domain.emotionRecord.service.EmotionRecordService;
+import org.dfbf.soundlink.domain.user.entity.User;
+import org.dfbf.soundlink.domain.user.repository.UserRepository;
+import org.dfbf.soundlink.global.comm.enums.Emotions;
+import org.dfbf.soundlink.global.exception.ResponseResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.dfbf.soundlink.global.comm.enums.Emotions.HAPPY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EmotionRecordServiceTest_Cache {
+    @InjectMocks
+    private EmotionRecordService emotionRecordService;
+    @Mock
+    private EmotionRecordCacheService emotionRecordCacheService;
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+    @Mock
+    private EmotionRecordRepository emotionRecordRepository;
+    @Mock
+    private SpotifyMusicRepository spotifyMusicRepository;
+    @Mock
+    private UserRepository userRepository;
+
+
+    /*@DisplayName("감정기록 작성(제목,가수,앨범,스포티파이아이디,감정,멘트):성공")
+    @Test
+    void saveEmotionRecordWithMusic_SUCCESS() {
+
+        // 각 테스트 전에 캐시 제거 호출은 아무 동작도 하지 않도록 설정
+        doNothing().when(emotionRecordCacheService)
+                .evictEmotionRecordCache(any(), any(), any());
+
+        // given
+        Long userId = 1L;
+        EmotionRecordRequestDTO requestDTO = new EmotionRecordRequestDTO(
+                "spotify1233", "New videoId", "New Title", "New Artist", "New Image", HAPPY, "Test comment"
+        );
+
+        User mockUser = mock(User.class);
+        SpotifyMusic newSpotifyMusic = new SpotifyMusic(requestDTO.spotifyId(), requestDTO.title(), requestDTO.artist(), requestDTO.albumImage(),requestDTO.videoId());
+        EmotionRecord newEmotionRecord = mock(EmotionRecord.class);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser)); // 사용자 조회 성공
+        when(spotifyMusicRepository.save(any(SpotifyMusic.class))).thenReturn(newSpotifyMusic); // 음악 저장
+        when(emotionRecordRepository.save(any(EmotionRecord.class))).thenReturn(newEmotionRecord); // 감정 기록 저장
+
+        // when
+        ResponseResult result = emotionRecordService.saveEmotionRecordWithMusic(userId, requestDTO);
+
+        // then
+        assertEquals(HttpStatus.OK.value(), result.getCode());
+        verify(spotifyMusicRepository).save(any(SpotifyMusic.class)); // 음악이 저장되었는지 검증
+        verify(emotionRecordRepository).save(any(EmotionRecord.class)); // 감정 기록이 저장되었는지 검증
+    }
+
+    //감정기록 삭제 : 성공
+    @DisplayName("감정기록 삭제:성공")
+    @Test
+    void deleteEmotionRecord_SUCCESS() {
+        // given
+        Long recordId = 1L;
+
+        // 모의 User, SpotifyMusic, Emotions 생성 및 스텁 처리
+        User mockUser = mock(User.class);
+        when(mockUser.getUserId()).thenReturn(100L);  // 예시 값
+
+        SpotifyMusic mockMusic = mock(SpotifyMusic.class);
+        when(mockMusic.getSpotifyId()).thenReturn("spotify123");
+
+        EmotionRecord mockRecord = mock(EmotionRecord.class);
+
+        // 실제 존재하는 EmotionRecord 모의 객체 (캐싱제거 처리로 추가)
+        when(mockRecord.getUser()).thenReturn(mockUser);
+        when(mockRecord.getSpotifyMusic()).thenReturn(mockMusic);
+        when(mockRecord.getEmotion()).thenReturn(Emotions.HAPPY);
+
+        // 채팅방 모의 객체 생성 (해당 EmotionRecord를 참조하는 채팅방 존재)
+        ChatRoom mockChatRoom = mock(ChatRoom.class);
+        List<ChatRoom> mockChatRooms = Collections.singletonList(mockChatRoom);
+
+        // 스텁 설정
+        when(chatRoomRepository.findByRecordId(mockRecord))
+                .thenReturn(mockChatRooms);
+        when(emotionRecordRepository.findByRecordId(recordId)).thenReturn(Optional.of(mockRecord));
+        when(emotionRecordRepository.deleteByRecordId(recordId)).thenReturn(1); // 삭제된 레코드 수 1개
+
+        // 캐시 제거 호출은 아무 동작도 하지 않도록 설정
+        doNothing().when(emotionRecordCacheService)
+                .evictEmotionRecordCache(any(), any(), any());
+
+        // when
+        ResponseResult result = emotionRecordService.deleteEmotionRecord(recordId);
+
+        // then
+        assertEquals(200, result.getCode());
+        verify(emotionRecordRepository).findByRecordId(recordId);
+        verify(chatRoomRepository).findByRecordId(mockRecord);
+        verify(chatRoomRepository).deleteAll(mockChatRooms);
+        verify(chatRoomRepository).flush();
+        verify(emotionRecordRepository).deleteByRecordId(recordId);
+        verify(emotionRecordRepository).flush();
+        verify(emotionRecordCacheService).evictEmotionRecordCache(any(), any(), any());
+    }
+
+
+    @Test
+    @DisplayName("감정 기록 수정 성공 테스트")
+    void updateEmotionRecord_Success() {
+
+        // 각 테스트 전에 캐시 제거 호출은 아무 동작도 하지 않도록 설정
+        doNothing().when(emotionRecordCacheService)
+                .evictEmotionRecordCache(any(), any(), any());
+
+        // given
+        Long recordId = 1L;
+        EmotionRecordUpdateRequestDTO updateDTO = new EmotionRecordUpdateRequestDTO(
+                "spotify1233", "New videoId", "New Title", "New Artist", "New Image","HAPPY", "Test comment"
+        );
+
+        // 기존 감정 기록 및 음악 정보
+        SpotifyMusic existingMusic = new SpotifyMusic("spotify123", "1234" ,"Old Title", "Old Artist", "Old Image");
+        EmotionRecord existingRecord = new EmotionRecord(
+                mock(User.class), Emotions.SAD, "Old Comment", existingMusic
+        );
+
+        // 기존 감정 기록 조회
+        when(emotionRecordRepository.findByRecordId(recordId)).thenReturn(Optional.of(existingRecord));
+        when(spotifyMusicRepository.findBySpotifyId(updateDTO.spotifyId())).thenReturn(Optional.of(existingMusic));
+
+        // when
+        ResponseResult result = emotionRecordService.updateEmotionRecord(recordId, updateDTO);
+
+        // then
+        assertEquals(200, result.getCode());
+        verify(emotionRecordRepository).findByRecordId(recordId);
+        verify(spotifyMusicRepository).findBySpotifyId(updateDTO.spotifyId());
+        verify(emotionRecordRepository, never()).save(any()); // update는 save 호출 안 함
+    }
+*/
+
+
+}


### PR DESCRIPTION
- 카카오 랜덤 닉네임 형식 변경 
- 메인 서비스에 캐싱 처리로 인한 문제가 발생하여 우선적으로 해당 로직을 비활성화 시킴