### PR TITLE
feat: SpotifyMusic 업데이트 시, 낙관적 락 추가

### DIFF
--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/entity/SpotifyMusic.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/entity/SpotifyMusic.java
@@ -20,6 +20,9 @@ public class SpotifyMusic {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Version
+    private Integer version;
+
     @Column(name = "spotify_id")
     private String spotifyId;
 

--- a/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
+++ b/src/main/java/org/dfbf/soundlink/domain/emotionRecord/service/EmotionRecordService.java
@@ -1,5 +1,6 @@
 package org.dfbf.soundlink.domain.emotionRecord.service;
 
+import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.dfbf.soundlink.domain.chat.entity.ChatRoom;
@@ -24,6 +25,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -181,6 +185,11 @@ public class EmotionRecordService {
     }
 
     @Transactional
+    @Retryable(
+            retryFor = OptimisticLockException.class, // 낙관적 락 충돌 시 재시도
+            maxAttempts = 3, // 최대 3번 재시도
+            backoff = @Backoff(delay = 100) // 100ms(0.1초) 대기 후 재시도
+    )
     public ResponseResult updateEmotionRecord(Long recordId, EmotionRecordUpdateRequestDTO updateDTO) {
         try {
             // 기존 감정 기록 조회
@@ -221,6 +230,16 @@ public class EmotionRecordService {
         } catch (Exception e) {
             return new ResponseResult(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
         }
+    }
+
+    // 낙관적 락 재시도 실패 시 실행되는 메서드
+    // Recover 어노테이션에 의해 실패 시, 자동 호출됨
+    @Recover
+    public ResponseResult recoverFromOptimisticLock(OptimisticLockException e, Long recordId, EmotionRecordUpdateRequestDTO updateDTO) {
+        log.error("감정 기록 업데이트 중 동시성 충돌 발생. recordId: {}, spotifyId: {}, error: {}",
+                recordId, updateDTO.spotifyId(), e.getMessage());
+
+        return new ResponseResult(ErrorCode.CONCURRENCY_ERROR, e.getMessage());
     }
 
     @Transactional

--- a/src/main/java/org/dfbf/soundlink/global/exception/ErrorCode.java
+++ b/src/main/java/org/dfbf/soundlink/global/exception/ErrorCode.java
@@ -72,8 +72,9 @@ public enum ErrorCode {
     CHAT_UNAUTHORIZED(HttpStatus.FORBIDDEN,"권한이 없습니다"),
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND,"채팅방을 찾을 수 없습니다."),
     CHAT_FAILED(HttpStatus.CONFLICT,"서버 내부 에러. 중복된 레코드가 존재합니다."),
-    CHAT_REQUEST_FAILED(HttpStatus.CONFLICT, "채팅 요청 실패");
+    CHAT_REQUEST_FAILED(HttpStatus.CONFLICT, "채팅 요청 실패"),
 
+    CONCURRENCY_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "재시도 실패. 동시성 충돌로 인해 업데이트 할 수 없습니다." );
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
- videoID 부분에서 동시성 문제 발생, 해당 문제 해결하기 위해 낙관적 락 적용
- 데이터 변경이 적은 편이고 조회된 videoID를 기반으로 수정하는 로직이 필요 없으므로 낙관적 락을 사용함